### PR TITLE
Pull features/rkenyon into master

### DIFF
--- a/docroot/quick_references/organisms_gene/correlated_genes.md
+++ b/docroot/quick_references/organisms_gene/correlated_genes.md
@@ -1,4 +1,4 @@
-# Correlated Genes Tab
+# Correlated Genes
 
 ## Overview
 The Correlated Genes Tab shows the genes that are either up or down-regulated with respect to selected gene in the Feature View. The values are based on the public transcriptomics data that are available in BV-BRC. 

--- a/docroot/quick_references/organisms_gene/interactions.md
+++ b/docroot/quick_references/organisms_gene/interactions.md
@@ -1,4 +1,4 @@
-# Interactions Tab, Feature-Level
+# Interactions, Feature-Level
 
 ## Overview
 The Interactions Tab provides experimentally and computationally derived host-pathogen protein-protein interaction data and visualizations from more than 15 public repositories, including [STRINGDB](https://string-db.org/), with a total of 55 million protein-protein interactions. Interactions are available at both the genome and feature levels, and are presented in tabular and graph format.

--- a/docroot/quick_references/organisms_gene/overview.md
+++ b/docroot/quick_references/organisms_gene/overview.md
@@ -1,4 +1,4 @@
-# Feature (Gene) Overview Tab
+# Feature (Gene) Overview
 
 ## Overview
 The Feature Overview Tab provides summary information for the selected genomic feature including identifiers, associated Genome information, Location, Sequence, Functional Properties, Special Properties, External Identifiers, Comments, and relevant PubMed articles.  

--- a/docroot/quick_references/organisms_gene/transcriptomics.md
+++ b/docroot/quick_references/organisms_gene/transcriptomics.md
@@ -1,4 +1,4 @@
-# Transcriptomics Tab, Gene-Level
+# Transcriptomics, Gene-Level
 
 ## Overview
 The Transcriptomics Tab in the Feature View provides expression data for the selected gene from all of the transcriptomics datasets in which the gene appears, including levels of expression based on Log ratio or Z score and the strains, gene modification, or experimental conditions. 

--- a/docroot/quick_references/organisms_genome/overview.md
+++ b/docroot/quick_references/organisms_genome/overview.md
@@ -1,4 +1,4 @@
-# Genome Overview Tab
+# Genome Overview
 
 ## Overview
 The Genome Overview Tab provides summary information for the selected genome including  genome sequence information, Genome Metadata, Genomic Features, Protein Features, Specialty Genes, and related PubMed Articles.  

--- a/docroot/quick_references/organisms_menu.rst
+++ b/docroot/quick_references/organisms_menu.rst
@@ -1,13 +1,13 @@
-Organisms
-=========
+Organisms and Data Types
+========================
 The top-level Organisms Menu provides direct access to genus-level data for bacteria and viruses in BV-BRC corresponding to `NIAID's Priority Pathogens <https://www.niaid.nih.gov/research/emerging-infectious-diseases-pathogens>`_. It also provides direct access to summary-level data for all bacteria, viruses, archaea, phages, and eukaryotic hosts in BV-BRC.
 
 .. image:: ./images/bv_organisms_menu.png
 
 Clicking on one of the menu items will display the corresponding taxon-level Overview page. From there, data are accessible at the taxon, genome/strain, and feature (gene, protein) levels, as described in the Quick Reference Guides below. 
 
-Browsing BV-BRC by Taxon
--------------------------
+Taxon-Level Data
+----------------
 
 .. toctree::
    :maxdepth: 1
@@ -33,8 +33,8 @@ Browsing BV-BRC by Taxon
    organisms_taxon/serology_data
 
 
-Browsing BV-BRC by Genome/Strain
---------------------------------
+Genome/Strain-Level Data
+------------------------
 
 .. toctree::
    :maxdepth: 1
@@ -44,8 +44,8 @@ Browsing BV-BRC by Genome/Strain
    organisms_genome/circular_genome_viewer
 
 
-Browsing BV-BRC by Gene/Protein
--------------------------------
+Gene/Protein-Level Data
+-----------------------
 
 .. toctree::
    :maxdepth: 1

--- a/docroot/quick_references/organisms_taxon/amr_phenotypes.md
+++ b/docroot/quick_references/organisms_taxon/amr_phenotypes.md
@@ -1,4 +1,4 @@
-# AMR Phenotypes Tab
+# AMR Phenotypes
 
 ## Overview
 The AMR Phenotypes Tab provides a tabular view of all of the bacterial AMR phenotype data for the selected taxon level, including the resistance phenotype (Resistant, Susceptible, Intermediate) and/or the minimum inhibitory concentration (MIC) value as measured by antibiogram (AMR panel) assay.

--- a/docroot/quick_references/organisms_taxon/domains_and_motifs.md
+++ b/docroot/quick_references/organisms_taxon/domains_and_motifs.md
@@ -1,3 +1,3 @@
-# Domains and Motifs Tab
+# Domains and Motifs
 
 ***Quick Reference Guide coming soon***

--- a/docroot/quick_references/organisms_taxon/epitopes.md
+++ b/docroot/quick_references/organisms_taxon/epitopes.md
@@ -1,3 +1,3 @@
-# Epitopes Tab
+# Epitopes
 
 ***Quick Reference Guide coming soon***

--- a/docroot/quick_references/organisms_taxon/experiments.rst
+++ b/docroot/quick_references/organisms_taxon/experiments.rst
@@ -1,5 +1,5 @@
-Experiments Tab
-===================
+Experiments
+===========
 Experiments data is presented in three primary displays: the Experiments and Comparisons Tables, the Gene List Table, and the Gene List Heatmap.  Details for each are provided from the links below.
 
 .. toctree::

--- a/docroot/quick_references/organisms_taxon/features.md
+++ b/docroot/quick_references/organisms_taxon/features.md
@@ -1,4 +1,4 @@
-# Features Tab
+# Features
 
 ## Overview
 The Features Tab provides a table of all the annotated genomic features (gene, CDS, mRNA, proteins, etc.) corresponding to the set of genomes in the selected Taxon View level or in the user-defined Genome Group.  From this page, features can be sorted, filtered, collected into groups, and downloaded. 

--- a/docroot/quick_references/organisms_taxon/genome_table.md
+++ b/docroot/quick_references/organisms_taxon/genome_table.md
@@ -1,4 +1,4 @@
-# Genomes Tab
+# Genomes Table
 
 ## Overview
 The Genomes Tab provides a list of all the genomes and associated metadata in corresponding to the selected Taxon View level or for the user-defined Genome Group. From this page, genomes can be sorted, filtered, collected into groups, and downloaded. 

--- a/docroot/quick_references/organisms_taxon/genomes.rst
+++ b/docroot/quick_references/organisms_taxon/genomes.rst
@@ -1,5 +1,5 @@
-Genomes Tab
-============
+Genomes
+=======
 The Genomes Tab provides a table listing of the genomes in the selected Taxon View (group of selected genomes), as described in the link below. Genomes in BV-BRC include extensive additional information including annotations and metadata.
 
 

--- a/docroot/quick_references/organisms_taxon/interactions.md
+++ b/docroot/quick_references/organisms_taxon/interactions.md
@@ -1,10 +1,10 @@
-# Interactions Tab, Taxon/Genome-Level
+# Interactions, Taxon/Genome-Level
 
 ## Overview
 The Interactions Tab provides experimentally and computationally derived host-pathogen protein-protein interaction data and visualizations from more than 15 public repositories, including [STRINGDB](https://string-db.org/), with a total of 55 million protein-protein interactions. Interactions are available at both the genome and gene levels, and are presented in tabular and graph format.
 
 ### See also
-  * [Interactions Tab, Gene-Level](../organisms_gene/interactions.html)
+  * [Interactions, Gene-Level](../organisms_gene/interactions.html)
 
 ## Accessing the Genome-Level Interactions Table
 Clicking the Interactions Tab in a Genome View displays the Interactions Table, listing of all of the interactions associated with the genes in that genome.

--- a/docroot/quick_references/organisms_taxon/overview.md
+++ b/docroot/quick_references/organisms_taxon/overview.md
@@ -1,4 +1,4 @@
-# Taxon Overview Tab
+# Taxonomic Overview
 
 ## Overview
 For the chosen taxon level, the Taxon Overview Tab provides summary information for corresponding data in BV-BRC, including Taxon Info, Reference/Representative Genomes, Genomes by Antimicrobial Resistance, Genomes by Metada, and relevant Recent PubMed Articles.  

--- a/docroot/quick_references/organisms_taxon/pathways.md
+++ b/docroot/quick_references/organisms_taxon/pathways.md
@@ -1,4 +1,4 @@
-# Pathways Tab
+# Pathways
 
 ## Overview
 The Pathways Tab provides access to the Comparative Pathway Tool, which facilitates identification of sets of pathways based on taxonomy, EC number, pathway ID, pathway name and/or specific annotation type. The Comparative Pathway Tool displays a table of unique pathways that match the search criteria. From there, specific pathways of interest can be selected and viewed in a heatmap or KEGG map.

--- a/docroot/quick_references/organisms_taxon/phylogeny.md
+++ b/docroot/quick_references/organisms_taxon/phylogeny.md
@@ -1,4 +1,4 @@
-# Phylogeny Tab
+# Phylogeny
 
 ## Overview
 The Phylogeny Tab and Phylogenetic Tree Viewer allow you to visualize and interact with genome trees. This tab is currently only displayed for bacterial genomes.

--- a/docroot/quick_references/organisms_taxon/protein_families.md
+++ b/docroot/quick_references/organisms_taxon/protein_families.md
@@ -1,4 +1,4 @@
-# Protein Families Tab
+# Protein Families
 
 ## Overview
 The Protein Families Tab provides access to the Protein Family Sorter, which enables examination of the distribution of computed protein families across sets of genomes. Filters for present, absent, or mixed can be used to refine the selection and an interactive heatmap provides a visual overview of the distribution.

--- a/docroot/quick_references/organisms_taxon/protein_structures.md
+++ b/docroot/quick_references/organisms_taxon/protein_structures.md
@@ -1,4 +1,4 @@
-# Protein Structure Data
+# Protein Structures
 
 ## Overview
 Protein structure data allows users to search for 3D protein structure files obtained from the [Protein Data Bank (PDB)](https://www.rcsb.org/). Protein(s) are associated with each PDB file UniProt database. One protein structure can be assigned to multiple GenBank protein records.

--- a/docroot/quick_references/organisms_taxon/proteins.md
+++ b/docroot/quick_references/organisms_taxon/proteins.md
@@ -1,4 +1,4 @@
-# Proteins Tab
+# Proteins
 
 ## Overview
 The Proteins Tab provides a table of all the annotated genomic features (gene, CDS, mRNA, proteins, etc.) corresponding to the set of genomes in the selected Taxon View level or in the user-defined Genome Group.  From this page, proteins can be sorted, filtered, collected into groups, and downloaded. 

--- a/docroot/quick_references/organisms_taxon/sequences.md
+++ b/docroot/quick_references/organisms_taxon/sequences.md
@@ -1,4 +1,4 @@
-# Sequences Tab
+# Sequences
 
 ## Overview
 The Sequences Tab provides a table of all the contiguous sequences (chromosome, contig, plasmid) that comprise the set of genomes corresponding to the selected Taxon View level or for the user-defined Genome Group. From this page, sequences can be sorted, filtered, collected into groups, and downloaded. 

--- a/docroot/quick_references/organisms_taxon/specialty_genes.md
+++ b/docroot/quick_references/organisms_taxon/specialty_genes.md
@@ -1,4 +1,4 @@
-# Speciality Genes Tab
+# Speciality Genes
 
 ## Overview
 The Specialty Genes Tab provides a table of all the annotated "specialty genes" (virulence factors, antibiotic resistance genes, drug targets, human homologs, transporters, and essential genes) corresponding to the set of genomes in the selected Taxon View level or in the user-defined Genome Group.  From this page, features can be sorted, filtered, collected into groups, and downloaded. 

--- a/docroot/quick_references/organisms_taxon/strains.md
+++ b/docroot/quick_references/organisms_taxon/strains.md
@@ -1,3 +1,3 @@
-# Strains Tab
+# Strains
 
 ***Quick Reference Guide coming soon.***

--- a/docroot/quick_references/organisms_taxon/subsystems.md
+++ b/docroot/quick_references/organisms_taxon/subsystems.md
@@ -1,4 +1,4 @@
-# Subsystems
+# Subsystems Protocol
 
 Bacterial subsystems are co-curated sets of biologically related functional roles across a reference set of genomes. They are units of expert knowledge about a single biological process like a whole metabolic pathway (Glycolysis), or a piece of a pathway (L-2-amino-adipate to lysine module), the subunits of a multi-unit enzyme (Urease) or the pieces of a structural unit like the ribosome. While building a subsystem the curator becomes an expert in this process, studying the literature and encoding the variants of such processes that occur in the reference genomes. 
 
@@ -10,6 +10,6 @@ Note that not all functional roles are always needed for a functional variant of
 The functional roles curated via subsystems are used in the construction of "Local" and "Global" Protein Families. We will periodically add new subsystems, compute new Local and Global families and project them to all bacterial genomes. Those updates will also be reflected in the bacterial annotation services to support proper functionality of associated comparative genomics tools.
 
 ## See also
-  * [Subsystems Tab](../organisms_taxon/subsystems_tab.html)
+  * [Subsystems Data](../organisms_taxon/subsystems_tab.html)
   * [Protein Families](../organisms_taxon/protein_families.html)
 

--- a/docroot/quick_references/organisms_taxon/subsystems_tab.md
+++ b/docroot/quick_references/organisms_taxon/subsystems_tab.md
@@ -1,4 +1,4 @@
-# Subsystems Tab
+# Subsystems
 
 ## Overview
 The Subsystems Tab provides access to a graphical display (pie chart) of subsystem superclasses asserted to a genome or a genome group. Each of the 11 superclasses of subsystems (Metabolism, Energy, Protein Processing etc.) can be expanded to their class and subclass levels. The Subsystems (green)- and Gene (yellow) counts provided in parenthesis link to tabular representations of the appropriate data.  

--- a/docroot/quick_references/organisms_taxon/taxonomy.md
+++ b/docroot/quick_references/organisms_taxon/taxonomy.md
@@ -1,4 +1,4 @@
-# Taxonomy Tab
+# Taxonomy
 
 ## Overview
 The Taxonomy Tab allows you to navigate through the taxonomic tree structure and access genomes at any level. BV-BRC uses the [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy) for taxonomic classification of bacterial genomes. In the event that a genome does not have a taxon id, it retains its genus and species names, but is assigned to Candidatus pending subsequent classification. For genomes where the exact strain is not known, e.g., for some clinical isolates, they are mapped to the closest species or genus levels and assigned the corresponding taxon ID.


### PR DESCRIPTION
Changes in `features/rkenyon` were stale, but ahead of master, and it didn't look like they were going to be included anytime soon. To avoid further conflict I want to pull `features/rkenyon` into `master` so that `master` is fully up to date and can be worked off of.