### PR TITLE
predict_structure recipes: multi-chain input applies to DNA and RNA too

### DIFF
--- a/docroot/tutorial/predict_structure/predict_structure_recipes.md
+++ b/docroot/tutorial/predict_structure/predict_structure_recipes.md
@@ -22,6 +22,8 @@ For the full reference of every form field see the [Quick Reference Guide](/quic
 
 **Inputs:** one FASTA file with multiple `>` records — each record becomes one chain. Soft limit: 26 chains and 10,000 total residues per job.
 
+**This applies to DNA and RNA too, not just protein.** The form's separate **Protein**, **DNA**, and **RNA** inputs all follow the same rule: a multi-record FASTA in any of them contributes one chain per record, and the chains from all three inputs are folded together as one complex. So a protein–DNA assembly is simply a protein FASTA in the Protein field plus a (possibly multi-record) DNA FASTA in the DNA field — for example, a transcription factor with a double-stranded binding site is one protein record plus two DNA records (one per strand). The 26-chain / 10,000-residue limits count all chains from all three inputs combined. DNA/RNA chains are supported by Boltz, OpenFold 3, and Chai-1 (not ESMFold or AlphaFold 2).
+
 ```
 >heavy_chain
 QVQLVQSGAEVKKPGASVKVSCKASGYTFT...


### PR DESCRIPTION
Recipe 1 framed multi-record FASTA → multi-chain purely in terms of protein. But the service form exposes separate **Protein**, **DNA**, and **RNA** FASTA inputs, and all three follow the same rule — one chain per `>` record, all chains from all three inputs folded together as one complex.

This adds that statement to Recipe 1, with a concrete protein–DNA example (a transcription factor with a double-stranded binding site = one protein record + two DNA records), notes that the 26-chain / 10,000-residue soft limits count all inputs combined, and names which tools accept nucleic-acid chains (Boltz, OpenFold 3, Chai-1 — not ESMFold or AlphaFold 2).

Reported in CEPI-dxkb/PredictStructureApp#52 by @architvasan. The backend behavior is confirmed unchanged: `parse_fasta_entities` yields one entity per record identically for protein, DNA, and RNA, and the limits are computed across all chains.