### PR TITLE
predict_structure docs: retire AlphaFold from user-facing flows, add ESMFold2 (all five files)

### DIFF
--- a/docroot/quick_references/services/predict_structure_api.md
+++ b/docroot/quick_references/services/predict_structure_api.md
@@ -120,7 +120,7 @@ The `values` object mirrors the basic app spec in [`app_specs/PredictStructure.j
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `tool` | enum | yes | `auto` \| `boltz` \| `openfold` \| `chai` \| `alphafold` \| `esmfold` |
+| `tool` | enum | yes | `auto` \| `boltz` \| `openfold` \| `chai` \| `esmfold` \| `esmfold2` \| `alphafold` (explicit-only; never auto-selected) |
 | `input_file` | wsfile (`ws://...`) | conditional | Protein FASTA. Required unless DNA / RNA / ligand / SMILES / `text_input` is given |
 | `dna_file` | wsfile | no | DNA FASTA (Boltz / OpenFold / Chai only) |
 | `rna_file` | wsfile | no | RNA FASTA (Boltz / OpenFold / Chai only) |
@@ -158,14 +158,15 @@ Even though the schema accepts any combination, the Perl preflight will reject c
 | `boltz` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `openfold` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `chai` | ✓ | ✓ | ✓ | — | ✓ |
-| `alphafold` | — | — | — | — | (built locally) |
+| `esmfold2` | ✓ | ✓ | ✓ | ✓ | optional `.a3m` upload (no MSA server) |
+| `alphafold` (explicit-only) | — | — | — | — | (built locally) |
 | `esmfold` | — | — | — | — | — |
 | `auto` | (forwarded; selector decides) | | | | conditional |
 
 Submitting `{ "tool": "alphafold", "dna_file": "ws://..." }` returns:
 
 ```
-error: AlphaFold 2 supports protein only; remove dna_file or change tool to boltz/openfold/chai.
+error: AlphaFold 2 does not support dna input (it supports protein only). Use Boltz-2, Chai-1, ESMFold2, or OpenFold 3, which support dna.
 ```
 
 ## Start parameters

--- a/docroot/quick_references/services/predict_structure_cli.md
+++ b/docroot/quick_references/services/predict_structure_cli.md
@@ -1,6 +1,6 @@
 # PredictStructure CLI Reference
 
-The `predict-structure` command-line tool is the workhorse beneath the BV-BRC Protein Structure Prediction Service. It exposes the same five engines (Boltz-2, OpenFold 3, Chai-1, AlphaFold 2, ESMFold) through a single Click-based interface with shared global options and per-tool subcommands.
+The `predict-structure` command-line tool is the workhorse beneath the BV-BRC Protein Structure Prediction Service. It exposes six engines (Boltz-2, OpenFold 3, Chai-1, ESMFold, ESMFold2, and — explicit-only — AlphaFold 2) through a single Click-based interface with shared global options and per-tool subcommands.
 
 You can run it three ways:
 
@@ -52,7 +52,7 @@ predict-structure [GLOBAL_FLAGS] <TOOL> [TOOL_FLAGS] --protein <FASTA> -o <DIR>
 predict-structure --job jobs.yaml -o <DIR>
 ```
 
-Where `<TOOL>` is one of `auto`, `boltz`, `openfold`, `chai`, `alphafold`, or `esmfold`. The CLI uses `click.group()`, so `predict-structure <tool> --help` shows the per-tool flag set.
+Where `<TOOL>` is one of `auto`, `boltz`, `openfold`, `chai`, `esmfold`, `esmfold2`, or `alphafold` (never chosen by `auto`; see below). The CLI uses `click.group()`, so `predict-structure <tool> --help` shows the per-tool flag set.
 
 ## Entity flags (inputs)
 
@@ -161,6 +161,18 @@ predict-structure esmfold --protein input.fasta -o output/ --fp16 --device cpu
 | `--chunk-size` | int | (none) | Chunk size for long sequences |
 | `--max-tokens-per-batch` | int | (none) | Max tokens per batch |
 
+### `esmfold2` — ESMFold2
+
+```bash
+predict-structure esmfold2 --protein input.fasta -o output/ --msa alignment.a3m
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--msa` | path | (none) | Optional uploaded `.a3m`; improves accuracy on hard targets. The MSA **server** is not available for ESMFold2. |
+
+ESMFold2 accepts protein, DNA, RNA, CCD ligands, and SMILES in one complex. Subprocess backend only. GPU (H200) required.
+
 ## Auto subcommand
 
 `predict-structure auto --protein input.fasta -o output/` runs the auto-selector. The selection algorithm:
@@ -168,17 +180,15 @@ predict-structure esmfold --protein input.fasta -o output/ --fp16 --device cpu
 ```
 if device == cpu and only protein:
     → ESMFold
-for tool in [boltz, openfold, chai, esmfold, alphafold]:
-    if tool in {alphafold, esmfold} and any non-protein entity:
-        skip
-    if tool in {boltz, openfold, chai} and protein and no MSA:
-        skip   # diffusion tools need real MSA; dummy single-sequence MSA produces unusable output
-    if tool == alphafold and AF database dir missing:
-        skip
+for tool in [boltz, openfold, chai, esmfold]:      # AlphaFold 2 is retired from auto (#90)
     if tool not installed:
         skip
+    if tool does not support the requested entity types:
+        skip
+    if tool in {boltz, openfold, chai} and protein and no MSA:
+        skip   # diffusion tools need a real MSA; a dummy single-sequence MSA produces unusable output
     return tool
-raise: no prediction tool found
+raise: no suitable tool  # names the reason: missing MSA vs unsupported inputs vs nothing installed
 ```
 
 ## Batch jobs (`--job`)
@@ -225,7 +235,7 @@ Each job lands in `output/job_000/`, `output/job_001/`, … Job manifest schema:
 
 The unified flags are mapped to each tool's native option name internally:
 
-| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 | ESMFold |
+| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 (explicit-only) | ESMFold |
 |---|---|---|---|---|---|
 | `--output-dir` | `--out_dir` | `--output_dir` | positional | `--output_dir` | `-o` |
 | `--num-samples` | `--diffusion_samples` | `--num_diffusion_samples` | `--num-diffn-samples` | (N/A) | (N/A) |

--- a/docroot/quick_references/services/predict_structure_service.md
+++ b/docroot/quick_references/services/predict_structure_service.md
@@ -11,6 +11,7 @@ The Protein Structure Prediction Service predicts the 3D atomic structure of pro
 | **Chai-1** | Diffusion (AF3-class) | Multi-chain protein complexes, ligands by CCD code |
 | **AlphaFold 2** | Co-evolutionary (MSA + Evoformer) | High-accuracy monomer / multimer when MSA is rich |
 | **ESMFold** | Single-sequence (protein language model) | Fast, CPU-capable monomers; orphan / designed sequences |
+| **ESMFold2** | Diffusion (protein-LM encoder, all-atom) | Protein / nucleic-acid / ligand complexes; fast; optional MSA for hard targets |
 
 The service picks the best available engine automatically when `Prediction Tool` is left at **Auto**, or you can pin a specific one. Parameter mapping, format conversion (FASTA → YAML / JSON, mmCIF → PDB, A3M → Parquet), and confidence normalization are handled for you. The output is a ranked set of structures plus a unified confidence report.
 
@@ -37,17 +38,18 @@ Choose the structure prediction engine. Leaving this at **Auto** lets the servic
 | `auto` | (auto-select) | all | yes |
 | `boltz` | Boltz-2 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
 | `openfold` | OpenFold 3 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
-| `chai` | Chai-1 | protein, DNA, RNA, CCD ligand | Upload required |
-| `alphafold` | AlphaFold 2 | protein only | Built from BV-BRC's local databases |
+| `chai` | Chai-1 | protein, DNA, RNA, SMILES ligand (CCD codes rejected — use SMILES, or Boltz/OpenFold) | Upload required |
+| `alphafold` | AlphaFold 2 (API/CLI only — not offered in the submission form; never auto-selected) | protein only | Built from BV-BRC's local databases |
 | `esmfold` | ESMFold | protein only | None (single-sequence) |
+| `esmfold2` | ESMFold2 | protein, DNA, RNA, CCD ligand, SMILES | Optional `.a3m` upload; MSA server not available |
 
-**Auto-select priority** (when `tool = auto`): Boltz → OpenFold → Chai → ESMFold → AlphaFold. The selector inspects your other inputs and falls back as follows:
+**Auto-select priority** (when `tool = auto`): Boltz → OpenFold → Chai → ESMFold. AlphaFold 2 is retired from automatic selection and runs only when named explicitly (API/CLI). The selector inspects your other inputs and falls back as follows:
 
 | Protein | DNA / RNA / ligand / SMILES | MSA File | → Auto picks |
 |:-:|:-:|:-:|---|
-| ✓ | — | — | ESMFold (fast single-sequence); AlphaFold if ESMFold is unavailable |
-| ✓ | — | ✓ | Boltz → OpenFold → Chai → ESMFold → AlphaFold |
-| ✓ | ✓ | — | **ERROR** — diffusion tools need MSA; AF / ESMFold cannot use DNA / RNA / ligand |
+| ✓ | — | — | ESMFold (fast single-sequence) |
+| ✓ | — | ✓ | Boltz → OpenFold → Chai → ESMFold |
+| ✓ | ✓ | — | **ERROR** — diffusion tools need an MSA; ESMFold cannot use DNA / RNA / ligand |
 | ✓ | ✓ | ✓ | Boltz → OpenFold → Chai |
 | — | DNA / RNA only | any | Boltz → OpenFold → Chai |
 
@@ -82,8 +84,8 @@ The **MSA Source** selector controls how the multiple sequence alignment is supp
 
 | Source | What happens | When to use |
 |---|---|---|
-| **None** | No MSA is supplied. | Default. Works with Auto (which will pick ESMFold for single-protein, no-MSA inputs), ESMFold, and AlphaFold 2 (which generates its own MSA from BV-BRC's local databases). |
-| **Precomputed MSA from Workspace** | A workspace file selector appears; pick a pre-computed `.a3m`, `.sto`, or `.pqt` file. The service uses it as-is. | Required for Boltz-2, OpenFold 3, and Chai-1. Generate the MSA elsewhere (ColabFold's MMseqs2 server, JackHMMER, or the AlphaFold preprocessing pipeline) and upload the result to your workspace. |
+| **None** | No MSA is supplied. | Default. Works with Auto (which picks ESMFold for single-protein, no-MSA inputs), ESMFold, and ESMFold2. |
+| **Precomputed MSA from Workspace** | A workspace file selector appears; pick a pre-computed `.a3m`, `.sto`, or `.pqt` file. The service uses it as-is. | Required for Boltz-2, OpenFold 3, and Chai-1. Optional for ESMFold2 (`.a3m` only; improves accuracy on hard targets). Generate the MSA elsewhere (e.g. ColabFold's MMseqs2 server or JackHMMER) and upload the result to your workspace. |
 | **Use MSA Server or Service** | BV-BRC computes the MSA with ColabFold (MMseqs2 against UniRef + ColabFoldDB) and feeds it to the selected engine. | When you don't have a pre-computed MSA on hand and the selected tool needs one (Boltz, OpenFold, Chai). Adds 30 s – 3 min to the job. |
 
 Accepted formats for uploaded MSAs:
@@ -94,7 +96,7 @@ Accepted formats for uploaded MSAs:
 | `.sto` | Stockholm | Boltz, OpenFold, Chai (after conversion) |
 | `.pqt`, `.aligned.pqt` | Parquet (Chai-native) | Chai (no conversion) |
 
-ESMFold ignores any MSA. AlphaFold 2 ignores uploaded MSAs and always builds its own from BV-BRC's local databases.
+ESMFold ignores any MSA. ESMFold2 accepts an uploaded `.a3m` but cannot use the MSA server — with *Use MSA Server* selected it folds single-sequence.
 
 ## Output
 

--- a/docroot/tutorial/predict_structure/predict_structure.md
+++ b/docroot/tutorial/predict_structure/predict_structure.md
@@ -186,7 +186,7 @@ Set **MSA Source** to *Precomputed MSA from Workspace* and upload an `.a3m`, `.s
 
 ### Job is queued for a long time
 
-GPU partitions are shared. ESMFold jobs have low resource requests and usually start within minutes; Boltz / OpenFold / Chai may wait longer. AlphaFold 2 jobs can wait significantly longer because they hold a GPU for an hour or more.
+GPU partitions are shared. ESMFold and ESMFold2 jobs have low resource requests and usually start within minutes; Boltz / OpenFold / Chai may wait longer.
 
 ### Result viewer doesn't render
 

--- a/docroot/tutorial/predict_structure/predict_structure_recipes.md
+++ b/docroot/tutorial/predict_structure/predict_structure_recipes.md
@@ -39,7 +39,7 @@ DIQMTQSPSSLSASVGDRVTITCRASQDIS...
 | Other inputs | leave empty |
 | Job Name | something descriptive — e.g. `antibody-fv-boltz` |
 
-**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare.
+**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare. ESMFold2 also folds complexes (protein, DNA, RNA, ligands) and is the fastest option — typically about a minute — at some accuracy cost on hard targets unless you supply an MSA.
 
 ## Recipe 2 — Protein with a cofactor (CCD code)
 
@@ -97,7 +97,7 @@ The service runs MMseqs2 against UniRef + ColabFoldDB and feeds the result to th
 
 **When *not* to use this:** if you already have an MSA from your own pipeline (JackHMMER, ColabFold local, etc.), upload it instead — your MSA is likely deeper / better filtered than the server's defaults.
 
-## Recipe 5 — Uploaded MSA with Boltz, OpenFold, or Chai
+## Recipe 5 — Uploaded MSA with Boltz, OpenFold, Chai, or ESMFold2
 
 **Goal:** highest-quality fold, with an MSA you've curated.
 
@@ -134,7 +134,7 @@ This is the cleanest way to A/B-test engines without rebuilding the form from sc
 These advanced knobs are *not* surfaced on the web form. Reach them via the CLI or JSON-RPC API:
 
 - `num_samples` — how many independent predictions to generate (default 5; useful for assessing ensemble disagreement)
-- `num_recycles` — recycling iterations (engine-specific defaults; AlphaFold defaults to 3)
+- `num_recycles` — recycling iterations (engine-specific defaults, typically 3)
 - `seed` — random seed for reproducibility (engine-specific)
 - `output_format` — restrict output to a subset (`pdb`, `cif`, `report`, `confidence`, …)
 - Per-engine flags — see each engine's adapter in `PredictStructureApp/adapters/`


### PR DESCRIPTION
Sweep of all five predict_structure documentation files, tracking three service changes: AlphaFold 2 retired from auto-selection and the submission form (CEPI-dxkb/PredictStructureApp#90), ESMFold2 selectable and production-verified (PredictStructureApp#75, incl. MSA upload per #95), and Chai's CCD rejection (#82).

## Per file

**quick reference (`_service.md`)** — MSA Source table and footer no longer describe AlphaFold; ESMFold2's MSA asymmetry stated (uploaded `.a3m` works, MSA server does not — selecting it folds single-sequence); auto-select priority corrected (it still ended in AlphaFold — false since #90); ESMFold2 added to both tool tables; Chai row corrected (claimed CCD support, rejects it since #82).

**tutorial** — GPU-wait note no longer warns about AlphaFold holding a GPU for an hour (not reachable from the form); ESMFold2 joins the fast tier.

**recipes** — `num_recycles` note de-AlphaFolded; complexes recipe mentions ESMFold2 as the fast option (~1 min); Recipe 5 (uploaded MSA) includes ESMFold2.

**API reference** — `tool` enum gains `esmfold2`, marks `alphafold` explicit-only/never auto-selected; capability matrix gains an esmfold2 row; example error updated to the real current text (which names the tools that DO support the input).

**CLI reference** — six engines with AlphaFold explicit-only; new `esmfold2` subcommand section (MSA-upload flag + no-MSA-server caveat); auto-selection pseudocode updated to the post-#90 algorithm.

## Deliberately kept

AlphaFold's subcommand documentation, `--af2-*` flags, CWL file names, and explicit-mode examples — the tool still runs when named via API/CLI, so erasing it would misdocument the service. Every remaining mention now presents it as explicit-only.

Companion UI PRs: BV-BRC-Web#1397 (AlphaFold out of the selector), #1398 (runtime hints), #1399 (ESMFold2 in).