### PR TITLE
predict_structure docs: multi-chain DNA/RNA, retire AlphaFold 2, add ESMFold2, correct MSA behavior

### DIFF
--- a/docroot/quick_references/services/predict_structure_api.md
+++ b/docroot/quick_references/services/predict_structure_api.md
@@ -122,12 +122,12 @@ The `values` object mirrors the basic app spec in [`app_specs/PredictStructure.j
 |---|---|---|---|
 | `tool` | enum | yes | `auto` \| `boltz` \| `openfold` \| `chai` \| `esmfold` \| `esmfold2` \| `alphafold` (explicit-only; never auto-selected) |
 | `input_file` | wsfile (`ws://...`) | conditional | Protein FASTA. Required unless DNA / RNA / ligand / SMILES / `text_input` is given |
-| `dna_file` | wsfile | no | DNA FASTA (Boltz / OpenFold / Chai only) |
-| `rna_file` | wsfile | no | RNA FASTA (Boltz / OpenFold / Chai only) |
-| `ligand` | array of string | no | CCD codes, each 1–3 alphanumeric chars (e.g. `["ATP", "NAG"]`) |
+| `dna_file` | wsfile | no | DNA FASTA (Boltz / OpenFold / Chai / ESMFold2) |
+| `rna_file` | wsfile | no | RNA FASTA (Boltz / OpenFold / Chai / ESMFold2) |
+| `ligand` | array of string | no | CCD codes, each 1–3 or 5 alphanumeric chars (e.g. `["ATP", "NAG", "A1H1F"]`). Rejected by Chai — use `smiles` there |
 | `smiles` | array of string | no | SMILES strings |
-| `text_input` | array of object | no | Inline sequences: `{ "sequence": "...", "type": "auto|protein|dna|rna" }`. Lets clients submit without a workspace file |
-| `msa_file` | wsfile | conditional | Pre-computed MSA (`.a3m`, `.sto`, `.pqt`). Required for Boltz / OpenFold / Chai unless `use_msa_server` is set; in that case BV-BRC computes the MSA with ColabFold |
+| `text_input` | array of object | no | Inline sequences: `{ "sequence": "...", "type": "auto\|protein\|dna\|rna" }`. Lets clients submit without a workspace file |
+| `msa_file` | wsfile | no | Pre-computed MSA (`.a3m`, `.sto`, `.pqt`; ESMFold2 accepts `.a3m` only). If omitted, BV-BRC automatically computes one with ColabFold for Boltz / OpenFold / Chai; ESMFold and ESMFold2 then fold single-sequence |
 | `debug` | boolean | no | Verbose service-side logging (sets `P3_DEBUG=1`) |
 | `output_path` | folder (`ws://...`) | yes | Workspace folder where the job result directory will be created |
 | `output_file` | string | yes | Job result name; results land at `${output_path}/.${output_file}/` |
@@ -157,7 +157,7 @@ Even though the schema accepts any combination, the Perl preflight will reject c
 |---|:-:|:-:|:-:|:-:|:-:|
 | `boltz` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `openfold` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `chai` | ✓ | ✓ | ✓ | — | ✓ |
+| `chai` | ✓ | ✓ | — | ✓ | ✓ |
 | `esmfold2` | ✓ | ✓ | ✓ | ✓ | optional `.a3m` upload (no MSA server) |
 | `alphafold` (explicit-only) | — | — | — | — | (built locally) |
 | `esmfold` | — | — | — | — | — |
@@ -166,7 +166,7 @@ Even though the schema accepts any combination, the Perl preflight will reject c
 Submitting `{ "tool": "alphafold", "dna_file": "ws://..." }` returns:
 
 ```
-error: AlphaFold 2 does not support dna input (it supports protein only). Use Boltz-2, Chai-1, ESMFold2, or OpenFold 3, which support dna.
+error: AlphaFold 2 does not support dna input (it supports protein only). Use Boltz-2, Chai-1, ESMFold2, and OpenFold 3, which support dna. Otherwise remove the dna input to run AlphaFold 2.
 ```
 
 ## Start parameters

--- a/docroot/quick_references/services/predict_structure_api.md
+++ b/docroot/quick_references/services/predict_structure_api.md
@@ -120,7 +120,7 @@ The `values` object mirrors the basic app spec in [`app_specs/PredictStructure.j
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `tool` | enum | yes | `auto` \| `boltz` \| `openfold` \| `chai` \| `alphafold` \| `esmfold` |
+| `tool` | enum | yes | `auto` \| `boltz` \| `openfold` \| `chai` \| `esmfold` \| `esmfold2` \| `alphafold` (explicit-only; never auto-selected) |
 | `input_file` | wsfile (`ws://...`) | conditional | Protein FASTA. Required unless DNA / RNA / ligand / SMILES / `text_input` is given |
 | `dna_file` | wsfile | no | DNA FASTA (Boltz / OpenFold / Chai only) |
 | `rna_file` | wsfile | no | RNA FASTA (Boltz / OpenFold / Chai only) |
@@ -158,14 +158,15 @@ Even though the schema accepts any combination, the Perl preflight will reject c
 | `boltz` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `openfold` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `chai` | ✓ | ✓ | ✓ | — | ✓ |
-| `alphafold` | — | — | — | — | (built locally) |
+| `esmfold2` | ✓ | ✓ | ✓ | ✓ | optional `.a3m` upload (no MSA server) |
+| `alphafold` (explicit-only) | — | — | — | — | (built locally) |
 | `esmfold` | — | — | — | — | — |
 | `auto` | (forwarded; selector decides) | | | | conditional |
 
 Submitting `{ "tool": "alphafold", "dna_file": "ws://..." }` returns:
 
 ```
-error: AlphaFold 2 supports protein only; remove dna_file or change tool to boltz/openfold/chai.
+error: AlphaFold 2 does not support dna input (it supports protein only). Use Boltz-2, Chai-1, ESMFold2, or OpenFold 3, which support dna.
 ```
 
 ## Start parameters

--- a/docroot/quick_references/services/predict_structure_cli.md
+++ b/docroot/quick_references/services/predict_structure_cli.md
@@ -1,6 +1,6 @@
 # PredictStructure CLI Reference
 
-The `predict-structure` command-line tool is the workhorse beneath the BV-BRC Protein Structure Prediction Service. It exposes the same five engines (Boltz-2, OpenFold 3, Chai-1, AlphaFold 2, ESMFold) through a single Click-based interface with shared global options and per-tool subcommands.
+The `predict-structure` command-line tool is the workhorse beneath the BV-BRC Protein Structure Prediction Service. It exposes six engines (Boltz-2, OpenFold 3, Chai-1, ESMFold, ESMFold2, and — explicit-only — AlphaFold 2) through a single Click-based interface with shared global options and per-tool subcommands.
 
 You can run it three ways:
 
@@ -52,7 +52,7 @@ predict-structure [GLOBAL_FLAGS] <TOOL> [TOOL_FLAGS] --protein <FASTA> -o <DIR>
 predict-structure --job jobs.yaml -o <DIR>
 ```
 
-Where `<TOOL>` is one of `auto`, `boltz`, `openfold`, `chai`, `alphafold`, or `esmfold`. The CLI uses `click.group()`, so `predict-structure <tool> --help` shows the per-tool flag set.
+Where `<TOOL>` is one of `auto`, `boltz`, `openfold`, `chai`, `esmfold`, `esmfold2`, or `alphafold` (never chosen by `auto`; see below). The CLI uses `click.group()`, so `predict-structure <tool> --help` shows the per-tool flag set.
 
 ## Entity flags (inputs)
 
@@ -161,6 +161,18 @@ predict-structure esmfold --protein input.fasta -o output/ --fp16 --device cpu
 | `--chunk-size` | int | (none) | Chunk size for long sequences |
 | `--max-tokens-per-batch` | int | (none) | Max tokens per batch |
 
+### `esmfold2` — ESMFold2
+
+```bash
+predict-structure esmfold2 --protein input.fasta -o output/ --msa alignment.a3m
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--msa` | path | (none) | Optional uploaded `.a3m`; improves accuracy on hard targets. The MSA **server** is not available for ESMFold2. |
+
+ESMFold2 accepts protein, DNA, RNA, CCD ligands, and SMILES in one complex. Subprocess backend only. GPU (H200) required.
+
 ## Auto subcommand
 
 `predict-structure auto --protein input.fasta -o output/` runs the auto-selector. The selection algorithm:
@@ -168,17 +180,15 @@ predict-structure esmfold --protein input.fasta -o output/ --fp16 --device cpu
 ```
 if device == cpu and only protein:
     → ESMFold
-for tool in [boltz, openfold, chai, esmfold, alphafold]:
-    if tool in {alphafold, esmfold} and any non-protein entity:
-        skip
-    if tool in {boltz, openfold, chai} and protein and no MSA:
-        skip   # diffusion tools need real MSA; dummy single-sequence MSA produces unusable output
-    if tool == alphafold and AF database dir missing:
-        skip
+for tool in [boltz, openfold, chai, esmfold]:      # AlphaFold 2 is retired from auto (#90)
     if tool not installed:
         skip
+    if tool does not support the requested entity types:
+        skip
+    if tool in {boltz, openfold, chai} and protein and no MSA:
+        skip   # diffusion tools need a real MSA; a dummy single-sequence MSA produces unusable output
     return tool
-raise: no prediction tool found
+raise: no suitable tool  # names the reason: missing MSA vs unsupported inputs vs nothing installed
 ```
 
 ## Batch jobs (`--job`)
@@ -225,7 +235,7 @@ Each job lands in `output/job_000/`, `output/job_001/`, … Job manifest schema:
 
 The unified flags are mapped to each tool's native option name internally:
 
-| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 | ESMFold |
+| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 (explicit-only) | ESMFold |
 |---|---|---|---|---|---|
 | `--output-dir` | `--out_dir` | `--output_dir` | positional | `--output_dir` | `-o` |
 | `--num-samples` | `--diffusion_samples` | `--num_diffusion_samples` | `--num-diffn-samples` | (N/A) | (N/A) |

--- a/docroot/quick_references/services/predict_structure_cli.md
+++ b/docroot/quick_references/services/predict_structure_cli.md
@@ -235,14 +235,14 @@ Each job lands in `output/job_000/`, `output/job_001/`, … Job manifest schema:
 
 The unified flags are mapped to each tool's native option name internally:
 
-| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 (explicit-only) | ESMFold |
-|---|---|---|---|---|---|
-| `--output-dir` | `--out_dir` | `--output_dir` | positional | `--output_dir` | `-o` |
-| `--num-samples` | `--diffusion_samples` | `--num_diffusion_samples` | `--num-diffn-samples` | (N/A) | (N/A) |
-| `--num-recycles` | `--recycling_steps` | `--num_recycles` | `--num-trunk-recycles` | implicit | `--num-recycles` |
-| `--seed` | (N/A) | `--seed` | `--seed` | `--random_seed` | (N/A) |
-| `--device` | `--accelerator` | `--device` | `--device` | implicit | `--cpu-only` |
-| `--msa` | injected into Boltz YAML `msa:` | JSON `main_msa_file_paths` | A3M → Parquet converted | (uses local DBs) | ignored |
+| Shared flag | Boltz-2 | OpenFold 3 | Chai-1 | AlphaFold 2 (explicit-only) | ESMFold | ESMFold2 |
+|---|---|---|---|---|---|---|
+| `--output-dir` | `--out_dir` | `--output_dir` | positional | `--output_dir` | `-o` | `--output-dir` |
+| `--num-samples` | `--diffusion_samples` | `--num_diffusion_samples` | `--num-diffn-samples` | (N/A) | (N/A) | `--num-diffusion-samples` |
+| `--num-recycles` | `--recycling_steps` | `--num_recycles` | `--num-trunk-recycles` | implicit | `--num-recycles` | `--num-loops` |
+| `--seed` | (N/A) | `--seed` | `--seed` | `--random_seed` | (N/A) | `--seed` |
+| `--device` | `--accelerator` | `--device` | `--device` | implicit | `--cpu-only` | `--cpu-only` |
+| `--msa` | injected into Boltz YAML `msa:` | JSON `main_msa_file_paths` | A3M → Parquet converted | (uses local DBs) | ignored | `.a3m` attached per chain |
 
 ## Examples
 

--- a/docroot/quick_references/services/predict_structure_service.md
+++ b/docroot/quick_references/services/predict_structure_service.md
@@ -11,6 +11,7 @@ The Protein Structure Prediction Service predicts the 3D atomic structure of pro
 | **Chai-1** | Diffusion (AF3-class) | Multi-chain protein complexes, ligands by CCD code |
 | **AlphaFold 2** | Co-evolutionary (MSA + Evoformer) | High-accuracy monomer / multimer when MSA is rich |
 | **ESMFold** | Single-sequence (protein language model) | Fast, CPU-capable monomers; orphan / designed sequences |
+| **ESMFold2** | Diffusion (protein-LM encoder, all-atom) | Protein / nucleic-acid / ligand complexes; fast; optional MSA for hard targets |
 
 The service picks the best available engine automatically when `Prediction Tool` is left at **Auto**, or you can pin a specific one. Parameter mapping, format conversion (FASTA → YAML / JSON, mmCIF → PDB, A3M → Parquet), and confidence normalization are handled for you. The output is a ranked set of structures plus a unified confidence report.
 
@@ -37,17 +38,18 @@ Choose the structure prediction engine. Leaving this at **Auto** lets the servic
 | `auto` | (auto-select) | all | yes |
 | `boltz` | Boltz-2 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
 | `openfold` | OpenFold 3 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
-| `chai` | Chai-1 | protein, DNA, RNA, CCD ligand | Upload required |
-| `alphafold` | AlphaFold 2 | protein only | Built from BV-BRC's local databases |
+| `chai` | Chai-1 | protein, DNA, RNA, SMILES ligand (CCD codes rejected — use SMILES, or Boltz/OpenFold) | Upload required |
+| `alphafold` | AlphaFold 2 (API/CLI only — not offered in the submission form; never auto-selected) | protein only | Built from BV-BRC's local databases |
 | `esmfold` | ESMFold | protein only | None (single-sequence) |
+| `esmfold2` | ESMFold2 | protein, DNA, RNA, CCD ligand, SMILES | Optional `.a3m` upload; MSA server not available |
 
-**Auto-select priority** (when `tool = auto`): Boltz → OpenFold → Chai → ESMFold → AlphaFold. The selector inspects your other inputs and falls back as follows:
+**Auto-select priority** (when `tool = auto`): Boltz → OpenFold → Chai → ESMFold. AlphaFold 2 is retired from automatic selection and runs only when named explicitly (API/CLI). The selector inspects your other inputs and falls back as follows:
 
 | Protein | DNA / RNA / ligand / SMILES | MSA File | → Auto picks |
 |:-:|:-:|:-:|---|
-| ✓ | — | — | ESMFold (fast single-sequence); AlphaFold if ESMFold is unavailable |
-| ✓ | — | ✓ | Boltz → OpenFold → Chai → ESMFold → AlphaFold |
-| ✓ | ✓ | — | **ERROR** — diffusion tools need MSA; AF / ESMFold cannot use DNA / RNA / ligand |
+| ✓ | — | — | ESMFold (fast single-sequence) |
+| ✓ | — | ✓ | Boltz → OpenFold → Chai → ESMFold |
+| ✓ | ✓ | — | **ERROR** — diffusion tools need an MSA; ESMFold cannot use DNA / RNA / ligand |
 | ✓ | ✓ | ✓ | Boltz → OpenFold → Chai |
 | — | DNA / RNA only | any | Boltz → OpenFold → Chai |
 
@@ -82,8 +84,8 @@ The **MSA Source** selector controls how the multiple sequence alignment is supp
 
 | Source | What happens | When to use |
 |---|---|---|
-| **None** | No MSA is supplied. | Default. Works with Auto (which will pick ESMFold for single-protein, no-MSA inputs), ESMFold, and AlphaFold 2 (which generates its own MSA from BV-BRC's local databases). |
-| **Precomputed MSA from Workspace** | A workspace file selector appears; pick a pre-computed `.a3m`, `.sto`, or `.pqt` file. The service uses it as-is. | Required for Boltz-2, OpenFold 3, and Chai-1. Generate the MSA elsewhere (ColabFold's MMseqs2 server, JackHMMER, or the AlphaFold preprocessing pipeline) and upload the result to your workspace. |
+| **None** | No MSA is supplied. | Default. Works with Auto (which picks ESMFold for single-protein, no-MSA inputs), ESMFold, and ESMFold2. |
+| **Precomputed MSA from Workspace** | A workspace file selector appears; pick a pre-computed `.a3m`, `.sto`, or `.pqt` file. The service uses it as-is. | Required for Boltz-2, OpenFold 3, and Chai-1. Optional for ESMFold2 (`.a3m` only; improves accuracy on hard targets). Generate the MSA elsewhere (e.g. ColabFold's MMseqs2 server or JackHMMER) and upload the result to your workspace. |
 | **Use MSA Server or Service** | BV-BRC computes the MSA with ColabFold (MMseqs2 against UniRef + ColabFoldDB) and feeds it to the selected engine. | When you don't have a pre-computed MSA on hand and the selected tool needs one (Boltz, OpenFold, Chai). Adds 30 s – 3 min to the job. |
 
 Accepted formats for uploaded MSAs:
@@ -94,7 +96,7 @@ Accepted formats for uploaded MSAs:
 | `.sto` | Stockholm | Boltz, OpenFold, Chai (after conversion) |
 | `.pqt`, `.aligned.pqt` | Parquet (Chai-native) | Chai (no conversion) |
 
-ESMFold ignores any MSA. AlphaFold 2 ignores uploaded MSAs and always builds its own from BV-BRC's local databases.
+ESMFold ignores any MSA. ESMFold2 accepts an uploaded `.a3m` but cannot use the MSA server — with *Use MSA Server* selected it folds single-sequence.
 
 ## Output
 

--- a/docroot/quick_references/services/predict_structure_service.md
+++ b/docroot/quick_references/services/predict_structure_service.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Protein Structure Prediction Service predicts the 3D atomic structure of proteins, protein complexes, and protein–DNA / RNA / ligand assemblies from sequence input. It exposes five state-of-the-art folding engines through a single unified form:
+The Protein Structure Prediction Service predicts the 3D atomic structure of proteins, protein complexes, and protein–DNA / RNA / ligand assemblies from sequence input. It exposes six state-of-the-art folding engines through a single unified form:
 
 | Engine | Family | Best for |
 |---|---|---|
@@ -36,9 +36,9 @@ Choose the structure prediction engine. Leaving this at **Auto** lets the servic
 | **Tool**  | **Model/Version** | **Entity support** | **MSA handling** |
 |:---|:---|---|---|
 | `auto` | (auto-select) | all | yes |
-| `boltz` | Boltz-2 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
-| `openfold` | OpenFold 3 | protein, DNA, RNA, CCD ligand, SMILES | Upload required |
-| `chai` | Chai-1 | protein, DNA, RNA, SMILES ligand (CCD codes rejected — use SMILES, or Boltz/OpenFold) | Upload required |
+| `boltz` | Boltz-2 | protein, DNA, RNA, CCD ligand, SMILES | Auto (ColabFold server) or upload |
+| `openfold` | OpenFold 3 | protein, DNA, RNA, CCD ligand, SMILES | Auto (ColabFold server) or upload |
+| `chai` | Chai-1 | protein, DNA, RNA, SMILES ligand (CCD codes rejected — use SMILES, or Boltz/OpenFold) | Auto (ColabFold server) or upload |
 | `alphafold` | AlphaFold 2 (API/CLI only — not offered in the submission form; never auto-selected) | protein only | Built from BV-BRC's local databases |
 | `esmfold` | ESMFold | protein only | None (single-sequence) |
 | `esmfold2` | ESMFold2 | protein, DNA, RNA, CCD ligand, SMILES | Optional `.a3m` upload; MSA server not available |
@@ -47,9 +47,9 @@ Choose the structure prediction engine. Leaving this at **Auto** lets the servic
 
 | Protein | DNA / RNA / ligand / SMILES | MSA File | → Auto picks |
 |:-:|:-:|:-:|---|
-| ✓ | — | — | ESMFold (fast single-sequence) |
+| ✓ | — | — | Boltz (the service auto-enables the ColabFold MSA server); ESMFold via the CLI with no MSA source |
 | ✓ | — | ✓ | Boltz → OpenFold → Chai → ESMFold |
-| ✓ | ✓ | — | **ERROR** — diffusion tools need an MSA; ESMFold cannot use DNA / RNA / ligand |
+| ✓ | ✓ | — | Boltz (MSA computed automatically) |
 | ✓ | ✓ | ✓ | Boltz → OpenFold → Chai |
 | — | DNA / RNA only | any | Boltz → OpenFold → Chai |
 
@@ -63,7 +63,7 @@ Protein sequence(s) in FASTA format (`.fasta`, `.fa`). For a multi-chain complex
 
 ### DNA
 
-DNA sequence(s) in FASTA format. Used as co-folding partners with proteins. **Tools that support DNA:** Boltz-2, OpenFold 3, Chai-1. Ignored by AlphaFold 2 and ESMFold.
+DNA sequence(s) in FASTA format. Used as co-folding partners with proteins. **Tools that support DNA:** Boltz-2, OpenFold 3, Chai-1, ESMFold2. Ignored by AlphaFold 2 and ESMFold.
 
 ### RNA
 
@@ -71,7 +71,7 @@ RNA sequence(s) in FASTA format. Same engine support as DNA.
 
 ## Ligands
 
-Optional small-molecule ligands to co-fold with the proteins. Supported by Boltz-2, OpenFold 3, and Chai-1.
+Optional small-molecule ligands to co-fold with the proteins. Supported by Boltz-2, OpenFold 3, Chai-1 (SMILES only — CCD codes are rejected), and ESMFold2.
 
 The form provides one ligand input with a **Notation** selector — pick **CCD codes** or **SMILES strings** and enter one ligand per line. Each notation is validated as you type; the first invalid line is reported inline. Submit can only carry one notation at a time, so if you need both standard cofactors and a novel small molecule, pick the notation that matches your less-trivial entries (typically SMILES for the novel ones).
 
@@ -84,7 +84,7 @@ The **MSA Source** selector controls how the multiple sequence alignment is supp
 
 | Source | What happens | When to use |
 |---|---|---|
-| **None** | No MSA is supplied. | Default. Works with Auto (which picks ESMFold for single-protein, no-MSA inputs), ESMFold, and ESMFold2. |
+| **None** | No MSA file is uploaded. For Boltz-2, OpenFold 3, Chai-1 (and Auto), the service automatically computes one with ColabFold. ESMFold and ESMFold2 fold single-sequence. | Default — works with every tool. |
 | **Precomputed MSA from Workspace** | A workspace file selector appears; pick a pre-computed `.a3m`, `.sto`, or `.pqt` file. The service uses it as-is. | Required for Boltz-2, OpenFold 3, and Chai-1. Optional for ESMFold2 (`.a3m` only; improves accuracy on hard targets). Generate the MSA elsewhere (e.g. ColabFold's MMseqs2 server or JackHMMER) and upload the result to your workspace. |
 | **Use MSA Server or Service** | BV-BRC computes the MSA with ColabFold (MMseqs2 against UniRef + ColabFoldDB) and feeds it to the selected engine. | When you don't have a pre-computed MSA on hand and the selected tool needs one (Boltz, OpenFold, Chai). Adds 30 s – 3 min to the job. |
 

--- a/docroot/tutorial/predict_structure/predict_structure.md
+++ b/docroot/tutorial/predict_structure/predict_structure.md
@@ -88,7 +88,7 @@ The *Result location* bar directly below the Job Name field previews this path a
 
 ![Form filled with example values showing the Result location preview](./images/03b_form_filled.png "Form filled with example values showing the Result location preview")
 
-> **Why `Auto`?** With only a protein and no MSA, the auto-selector picks **ESMFold** — it's the only engine that runs without an MSA on a single sequence (see the [tool selector decision tree](/quick_references/services/predict_structure_service#prediction-tool)). If you pick `boltz` or `chai` without uploading an MSA, the submission will fail with a policy error.
+> **Why `Auto`?** With only a protein and no uploaded MSA, the service automatically computes one with ColabFold and the auto-selector picks **Boltz** (see the [tool selector decision tree](/quick_references/services/predict_structure_service#prediction-tool)). Picking `boltz`, `openfold`, or `chai` without an uploaded MSA works the same way — the MSA is computed for you, adding roughly 30 s – 3 min. For the fastest single-protein result, pick `esmfold` or `esmfold2` directly.
 
 ## Step 5 — Submit
 

--- a/docroot/tutorial/predict_structure/predict_structure.md
+++ b/docroot/tutorial/predict_structure/predict_structure.md
@@ -186,7 +186,7 @@ Set **MSA Source** to *Precomputed MSA from Workspace* and upload an `.a3m`, `.s
 
 ### Job is queued for a long time
 
-GPU partitions are shared. ESMFold jobs have low resource requests and usually start within minutes; Boltz / OpenFold / Chai may wait longer. AlphaFold 2 jobs can wait significantly longer because they hold a GPU for an hour or more.
+GPU partitions are shared. ESMFold and ESMFold2 jobs have low resource requests and usually start within minutes; Boltz / OpenFold / Chai may wait longer.
 
 ### Result viewer doesn't render
 

--- a/docroot/tutorial/predict_structure/predict_structure_recipes.md
+++ b/docroot/tutorial/predict_structure/predict_structure_recipes.md
@@ -22,7 +22,7 @@ For the full reference of every form field see the [Quick Reference Guide](/quic
 
 **Inputs:** one FASTA file with multiple `>` records — each record becomes one chain. Soft limit: 26 chains and 10,000 total residues per job.
 
-**This applies to DNA and RNA too, not just protein.** The form's separate **Protein**, **DNA**, and **RNA** inputs all follow the same rule: a multi-record FASTA in any of them contributes one chain per record, and the chains from all three inputs are folded together as one complex. So a protein–DNA assembly is simply a protein FASTA in the Protein field plus a (possibly multi-record) DNA FASTA in the DNA field — for example, a transcription factor with a double-stranded binding site is one protein record plus two DNA records (one per strand). The 26-chain / 10,000-residue limits count all chains from all three inputs combined. DNA/RNA chains are supported by Boltz, OpenFold 3, and Chai-1 (not ESMFold or AlphaFold 2).
+**This applies to DNA and RNA too, not just protein.** The form's separate **Protein**, **DNA**, and **RNA** inputs all follow the same rule: a multi-record FASTA in any of them contributes one chain per record, and the chains from all three inputs are folded together as one complex. So a protein–DNA assembly is simply a protein FASTA in the Protein field plus a (possibly multi-record) DNA FASTA in the DNA field — for example, a transcription factor with a double-stranded binding site is one protein record plus two DNA records (one per strand). The 26-chain / 10,000-residue limits count all chains from all three inputs combined. DNA/RNA chains are supported by Boltz, OpenFold 3, Chai-1, and ESMFold2 (not ESMFold or AlphaFold 2).
 
 ```
 >heavy_chain
@@ -41,7 +41,7 @@ DIQMTQSPSSLSASVGDRVTITCRASQDIS...
 | Other inputs | leave empty |
 | Job Name | something descriptive — e.g. `antibody-fv-boltz` |
 
-**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare. ESMFold2 also folds complexes (protein, DNA, RNA, ligands) and is the fastest option — typically about a minute — at some accuracy cost on hard targets unless you supply an MSA.
+**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare. ESMFold2 also folds complexes (protein, DNA, RNA, ligands) and is the fastest option — typically a few minutes — at some accuracy cost on hard targets unless you supply an MSA.
 
 ## Recipe 2 — Protein with a cofactor (CCD code)
 
@@ -109,7 +109,7 @@ The service runs MMseqs2 against UniRef + ColabFoldDB and feeds the result to th
 
 | Field | Value |
 |---|---|
-| Prediction Tool | `Boltz` (default), or `OpenFold` / `Chai` to compare |
+| Prediction Tool | `Boltz` (default), `OpenFold` / `Chai` to compare, or `ESMFold2` (accepts `.a3m` uploads only) |
 | Protein | the query FASTA matching the MSA's first sequence |
 | MSA Source | **Precomputed MSA from Workspace** |
 | MSA File | the uploaded `.a3m` / `.sto` / `.pqt` file |

--- a/docroot/tutorial/predict_structure/predict_structure_recipes.md
+++ b/docroot/tutorial/predict_structure/predict_structure_recipes.md
@@ -22,6 +22,8 @@ For the full reference of every form field see the [Quick Reference Guide](/quic
 
 **Inputs:** one FASTA file with multiple `>` records — each record becomes one chain. Soft limit: 26 chains and 10,000 total residues per job.
 
+**This applies to DNA and RNA too, not just protein.** The form's separate **Protein**, **DNA**, and **RNA** inputs all follow the same rule: a multi-record FASTA in any of them contributes one chain per record, and the chains from all three inputs are folded together as one complex. So a protein–DNA assembly is simply a protein FASTA in the Protein field plus a (possibly multi-record) DNA FASTA in the DNA field — for example, a transcription factor with a double-stranded binding site is one protein record plus two DNA records (one per strand). The 26-chain / 10,000-residue limits count all chains from all three inputs combined. DNA/RNA chains are supported by Boltz, OpenFold 3, and Chai-1 (not ESMFold or AlphaFold 2).
+
 ```
 >heavy_chain
 QVQLVQSGAEVKKPGASVKVSCKASGYTFT...

--- a/docroot/tutorial/predict_structure/predict_structure_recipes.md
+++ b/docroot/tutorial/predict_structure/predict_structure_recipes.md
@@ -39,7 +39,7 @@ DIQMTQSPSSLSASVGDRVTITCRASQDIS...
 | Other inputs | leave empty |
 | Job Name | something descriptive — e.g. `antibody-fv-boltz` |
 
-**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare.
+**Why Boltz for complexes?** Boltz, OpenFold 3, and Chai-1 are all AF3-class diffusion models with strong multimer performance. Boltz is the auto-selector's first choice when an MSA is available; OpenFold and Chai are reasonable swaps if you want to compare. ESMFold2 also folds complexes (protein, DNA, RNA, ligands) and is the fastest option — typically about a minute — at some accuracy cost on hard targets unless you supply an MSA.
 
 ## Recipe 2 — Protein with a cofactor (CCD code)
 
@@ -97,7 +97,7 @@ The service runs MMseqs2 against UniRef + ColabFoldDB and feeds the result to th
 
 **When *not* to use this:** if you already have an MSA from your own pipeline (JackHMMER, ColabFold local, etc.), upload it instead — your MSA is likely deeper / better filtered than the server's defaults.
 
-## Recipe 5 — Uploaded MSA with Boltz, OpenFold, or Chai
+## Recipe 5 — Uploaded MSA with Boltz, OpenFold, Chai, or ESMFold2
 
 **Goal:** highest-quality fold, with an MSA you've curated.
 
@@ -134,7 +134,7 @@ This is the cleanest way to A/B-test engines without rebuilding the form from sc
 These advanced knobs are *not* surfaced on the web form. Reach them via the CLI or JSON-RPC API:
 
 - `num_samples` — how many independent predictions to generate (default 5; useful for assessing ensemble disagreement)
-- `num_recycles` — recycling iterations (engine-specific defaults; AlphaFold defaults to 3)
+- `num_recycles` — recycling iterations (engine-specific defaults, typically 3)
 - `seed` — random seed for reproducibility (engine-specific)
 - `output_format` — restrict output to a subset (`pdb`, `cif`, `report`, `confidence`, …)
 - Per-engine flags — see each engine's adapter in `PredictStructureApp/adapters/`


### PR DESCRIPTION
Consolidated PR — reviewed, fixed, and merged in the fork first (wilke/BV-BRC-Docs#2). Supersedes #281 and #282, which will be closed in its favor.

## Changes across the five predict_structure files

**Recipe 1: multi-chain applies to DNA and RNA too** (CEPI-dxkb/PredictStructureApp#52, @architvasan) — the multi-record-FASTA → multi-chain rule holds identically for the Protein, DNA, and RNA inputs, all folded together as one complex; includes a protein–DNA example and the combined 26-chain/10k-residue limits.

**AlphaFold 2 retired from user-facing flows** (PredictStructureApp#90). The auto-selection docs still ended the priority chain in AlphaFold and offered it as a fallback — false since the retirement. Every remaining mention now presents it as explicit-only (API/CLI); its subcommand docs, `--af2-*` flags, and CWL names are deliberately kept because the tool still runs when named.

**ESMFold2 added everywhere it was missing** (PredictStructureApp#75): both tool tables, the capability matrix, resource estimates, per-input tool lists, a CLI subcommand section, the parameter-mapping column (from the adapter's actual `build_command`), and Recipe 5 — always with the MSA asymmetry stated: uploaded `.a3m` only; no MSA server; server selection folds single-sequence.

**MSA behavior corrected to what the service actually does.** Multiple passages (including the tutorial's *Why Auto?* box) claimed no-MSA auto picks ESMFold and that Boltz/Chai fail with a policy error without an upload. In reality the service auto-computes an MSA with ColabFold whenever none is uploaded, and Auto resolves to **Boltz** (service acceptance matrix, case X01). All affected passages rewritten.

**Factual fixes**: the API compatibility table had Chai's ligand cells inverted (CCD is rejected since PredictStructureApp#82; SMILES is supported); the CCD rule updated to 1–3 **or 5** alphanumeric (wwPDB issues 5-char IDs since 2023; PredictStructureApp#48); the example error message now matches the service's real output verbatim; a table-breaking unescaped `|` fixed.

Companion UI PR: BV-BRC-Web (consolidated, same review cycle).