### PR TITLE
docs: add StabiliNNator quick reference and API reference

### DIFF
--- a/docroot/quick_references/services/stabilinnator_api.md
+++ b/docroot/quick_references/services/stabilinnator_api.md
@@ -1,0 +1,183 @@
+# StabiliNNator API Reference
+
+This document describes the network API used to submit and monitor Protein Stability Prediction (StabiliNNator) jobs. The envelope is shared with every other BV-BRC service — only the `values` payload is service-specific.
+
+> **Scope.** This is the *AppService* JSON-RPC interface — the one the web form talks to when you click **Submit Job**. The public REST data API at `https://www.bv-brc.org/api/` (documented at <https://www.bv-brc.org/api/doc/>) is a different endpoint and is not covered here.
+
+## Transport
+
+JSON-RPC 2.0 over HTTPS POST, with the BV-BRC-specific MIME type `application/jsonrpc+json` (not plain `application/json`).
+
+```
+POST <serviceAPI>
+Content-Type: application/jsonrpc+json
+Authorization: <BV-BRC auth token>
+X-Requested-With: false
+```
+
+Request body:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "AppService.start_app2",
+  "params": ["StabiliNNator", { ...values... }, { ...start_params... }]
+}
+```
+
+Response on success:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [ { "id": "<task-id>", "app": { "id": "StabiliNNator" }, ... } ]
+}
+```
+
+The current production AppService endpoint is `https://www.bv-brc.org/services/AppService`.
+
+## Authentication
+
+Every call requires a BV-BRC auth token in the `Authorization` header. The UI obtains one through the login flow; for programmatic use see the `p3-login` / `p3-token` tools shipped with the BV-BRC CLI.
+
+## Parameters
+
+The `values` object mirrors the app spec in [`app_specs/StabiliNNator.json`](https://github.com/CEPI-dxkb/stabiliNNatorApp/blob/main/app_specs/StabiliNNator.json).
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `input_file` | wsfile (`ws://...`) | yes | — | Protein structure in PDB or mmCIF format. Must contain standard amino acids with CA atoms |
+| `analysis_type` | enum | yes | `both` | `proline` \| `disulfide` \| `both` |
+| `output_path` | folder (`ws://...`) | yes | — | Workspace folder where the job result directory will be created |
+| `output_file` | string | yes | — | Job result name; results land at `${output_path}/.${output_file}/` |
+| `theme` | enum | no | `bvbrc` | Report styling: `bvbrc` \| `editorial`. Presentation only |
+| `accelerator` | enum | no | `cpu` | `cpu` \| `gpu`. CPU is recommended and normally faster — see [Choosing a device](#choosing-a-device) |
+| `hidden_dim` | int | no | `32` | Network hidden dimension. Both shipped models were trained with 32; change only for custom-trained models |
+| `dry_run` | boolean | no | `false` | Validate inputs and workspace access, then stop without predicting |
+
+Workspace files use the `ws://<user>@BVBRC/<path>` URI scheme.
+
+### Validation rules enforced by the service
+
+`App-StabiliNNator.pl` rejects the submission before running any prediction if:
+
+1. `output_path` is absent.
+2. `output_file` is absent. Both are checked explicitly in the service script — results are written to `${output_path}/.${output_file}/`, so a missing name has nowhere valid to land.
+3. `input_file` is absent.
+4. The input parses as neither PDB (an `ATOM`/`HETATM` record) nor mmCIF (a `data_`/`loop_` block with `_atom_site.` records).
+
+`analysis_type` is validated against its enum by the framework before the service script runs.
+
+### Choosing a device
+
+`accelerator` defaults to `cpu`, and that is the recommended setting. The two models are 14–22 KB; CUDA initialization costs several seconds, which exceeds the compute it saves. Setting `gpu` requests a GPU and, if CUDA is unavailable at runtime, the job fails rather than silently falling back.
+
+Note that jobs are *scheduled* on a GPU partition regardless of this setting. That is a placement constraint — the shared container image is staged on those nodes — and not a statement about how inference runs.
+
+## Start parameters
+
+The `start_params` (3rd argument) is a bag of UI hints attached by the Web form: `parent_id`, `workflow_id`, `comment`. Pass `{}` if you have nothing to set.
+
+## Preflight
+
+The AppService calls preflight internally before scheduling; clients do not call it directly. StabiliNNator reports a fixed estimate, independent of input size:
+
+```json
+{
+  "cpu": 2,
+  "memory": "1G",
+  "runtime": 600,
+  "storage": "1G",
+  "policy_data": { "gpu_count": 0, "partition": "gpu2" }
+}
+```
+
+The 10-minute allowance is dominated by container staging rather than inference, which is sub-second. `gpu_count` is 0 because inference runs on CPU.
+
+## Results
+
+On success the workspace contains a job directory at `${output_path}/.${output_file}/`, and the task's `output_files` lists its contents:
+
+```
+${output_path}/.${output_file}/
+├── stabilinnator_report.html        # fixed name — the user-facing entry point
+├── <input>_proline.pdb              # probability in the B-factor column
+├── <input>_disulfide.pdb
+├── <input>_proline_summary.tsv      # ranked, highest probability first
+├── <input>_disulfide_summary.tsv
+└── <input>_summary.json             # top 25 sites per analysis
+```
+
+`<input>` is the basename of the input structure. Files for an analysis that was not requested are absent. The report filename is fixed, so a client can locate it without knowing the input name.
+
+`<input>_summary.json` is the machine-readable entry point:
+
+```json
+{
+  "input": "crambin.pdb",
+  "analysis_type": "both",
+  "proline": {
+    "top_sites": [
+      { "rank": 1, "chain": "A", "pos": 21, "icode": "",
+        "residue": "THR", "probability": 0.97 }
+    ]
+  },
+  "disulfide": {
+    "cys_sites": [
+      { "rank": 1, "chain": "A", "pos": 3, "icode": "",
+        "residue": "CYS", "probability": 1 }
+    ]
+  }
+}
+```
+
+Sites carry `"note": "already PRO"` where a high-scoring proline position is already a proline and therefore not an actionable substitution.
+
+## Example request — both analyses
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "AppService.start_app2",
+  "params": [
+    "StabiliNNator",
+    {
+      "input_file": "ws://awilke@BVBRC/home/structures/crambin.pdb",
+      "analysis_type": "both",
+      "output_path": "ws://awilke@BVBRC/home/jobs/",
+      "output_file": "crambin-stability-2026-08-25"
+    },
+    {}
+  ]
+}
+```
+
+## Example request — disulfide only, from a predicted structure
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "AppService.start_app2",
+  "params": [
+    "StabiliNNator",
+    {
+      "input_file": "ws://awilke@BVBRC/home/jobs/.spike-boltz/predictions/rank_1.pdb",
+      "analysis_type": "disulfide",
+      "output_path": "ws://awilke@BVBRC/home/jobs/",
+      "output_file": "spike-disulfide"
+    },
+    { "comment": "prefusion stabilization candidates" }
+  ]
+}
+```
+
+Chaining the two services this way — predict a structure, then score it for stabilizing mutations — is the common workflow.
+
+## See also
+
+- [Quick Reference](/quick_references/services/stabilinnator_service)
+- [PredictStructure API Reference](/quick_references/services/predict_structure_api)

--- a/docroot/quick_references/services/stabilinnator_api.md
+++ b/docroot/quick_references/services/stabilinnator_api.md
@@ -53,7 +53,7 @@ The `values` object mirrors the app spec in [`app_specs/StabiliNNator.json`](htt
 | `output_path` | folder (`ws://...`) | yes | — | Workspace folder where the job result directory will be created |
 | `output_file` | string | yes | — | Job result name; results land at `${output_path}/.${output_file}/` |
 | `theme` | enum | no | `bvbrc` | Report styling: `bvbrc` \| `editorial`. Presentation only |
-| `accelerator` | enum | no | `cpu` | `cpu` \| `gpu`. CPU is recommended and normally faster — see [Choosing a device](#choosing-a-device) |
+| `accelerator` | enum | no | `cpu` | `cpu` \| `gpu`. CPU is recommended and normally faster — see *Choosing a device* below |
 | `hidden_dim` | int | no | `32` | Network hidden dimension. Both shipped models were trained with 32; change only for custom-trained models |
 | `dry_run` | boolean | no | `false` | Validate inputs and workspace access, then stop without predicting |
 

--- a/docroot/quick_references/services/stabilinnator_service.md
+++ b/docroot/quick_references/services/stabilinnator_service.md
@@ -1,0 +1,159 @@
+# Protein Stability Prediction Service (stabiliNNator)
+
+## Overview
+
+The Protein Stability Prediction Service identifies positions in an existing protein structure where a targeted mutation is likely to increase thermal stability. It takes a 3D structure — not a sequence — and scores every residue with a graph neural network.
+
+Two complementary analyses are available, and they can be run together in one job:
+
+| Analysis | Question it answers | Scored residues |
+|---|---|---|
+| **proliNNator** | Which positions would tolerate, or benefit from, substitution to proline? | All standard amino acids |
+| **disulfiNNate** | Which cysteine positions are likely to form a stabilizing disulfide bond? | Cysteines (CYS / CYX) |
+
+Both models are Graph Attention Networks that treat the structure as a graph of residues and their spatial neighbors. Each returns a probability between 0 and 1 per residue, written into the **B-factor column** of an annotated PDB so that any structure viewer can color by it directly.
+
+Proline substitution and disulfide engineering are two of the most widely used strategies for rigidifying a protein — for example, stabilizing a viral glycoprotein in its prefusion conformation for vaccine design. This service ranks candidate positions so that wet-lab effort can be spent on the most promising handful.
+
+## See also
+
+- [Protein Stability Prediction API Reference](/quick_references/services/stabilinnator_api)
+- [Protein Structure Prediction Service](/quick_references/services/predict_structure_service) — generates the structures this service scores
+
+## Using the Protein Stability Prediction Service
+
+The **Protein Stability Prediction** submenu option under the **Services** main menu (Protein Tools category) opens the input form. *Note: You must be logged into BV-BRC to use this service.*
+
+If you do not already have a structure, run the [Protein Structure Prediction Service](/quick_references/services/predict_structure_service) first and use its top-ranked PDB as the input here.
+
+## Options
+
+### Input Structure File
+
+A protein structure in **PDB** or **mmCIF** format, selected from your workspace. The structure must contain standard amino acids with CA atoms — the graph is built from residue positions, so a backbone trace at minimum is required.
+
+Two input characteristics are handled automatically:
+
+- **NMR / multi-model ensembles.** Only the first model is scored. Without this, a 38-model ensemble of a 20-residue peptide would be read as 760 concatenated residues and the scores would be meaningless.
+- **Multiple chains.** All chains present are scored; results identify each residue by chain, position, and insertion code.
+
+### Analysis Type
+
+Which analysis to run.
+
+| Value | Runs | Produces |
+|---|---|---|
+| `both` *(default)* | proliNNator and disulfiNNate | Both annotated PDBs and both ranked summaries |
+| `proline` | proliNNator only | Proline outputs only |
+| `disulfide` | disulfiNNate only | Disulfide outputs only |
+
+`both` is the common case; the two analyses are independent and together take only a few seconds longer than either alone.
+
+### Report Theme
+
+Visual styling for the generated HTML report.
+
+| Value | Description |
+|---|---|
+| `bvbrc` *(default)* | Matches BV-BRC portal styling |
+| `editorial` | Alternative editorial layout |
+
+This affects presentation only — the underlying results are identical.
+
+### Advanced options
+
+These rarely need changing.
+
+| Field | Default | Description |
+|---|---|---|
+| **Compute Device** | `cpu` | `cpu` or `gpu`. CPU is recommended and is normally *faster*: the models are small (14–22 KB), so CUDA initialization overhead exceeds any compute savings. |
+| **Hidden Dimension** | `32` | Network hidden dimension. Both shipped models were trained with 32; change only when supplying custom-trained models. |
+| **Dry Run** | off | Validates workspace access and input parsing, then stops without running predictions. |
+
+## Output
+
+Every submission creates a **job** with the name you give it. A workspace object named after the job is created inside the Output Folder and holds all job-related information — parameters, status, logs, and the results themselves.
+
+```
+<Output Folder>/<Job Name>
+```
+
+### Output Folder
+
+The workspace folder where the job will be created. Must already exist, or create one from the folder selector.
+
+### Job Name
+
+Identifier for this run, used as the workspace object name. Results are written to `<Output Folder>/.<Job Name>/`. Give each run its own name; two jobs sharing a name write into the same folder.
+
+## Output Results
+
+A completed job contains the following files. `<input>` is the basename of the input structure, so scoring `crambin.pdb` yields `crambin_proline.pdb` and so on.
+
+```
+<job_name>/
+├── stabilinnator_report.html        # Interactive HTML report — start here
+├── <input>_proline.pdb              # Structure, proline probability in B-factor
+├── <input>_disulfide.pdb            # Structure, disulfide probability in B-factor
+├── <input>_proline_summary.tsv      # Full ranking, highest probability first
+├── <input>_disulfide_summary.tsv    # Cysteines only, ranked
+└── <input>_summary.json             # Combined machine-readable summary
+```
+
+Files for an analysis you did not request are simply absent.
+
+### The HTML report
+
+`stabilinnator_report.html` is self-contained — no network access is needed to view it, and it can be downloaded and shared as a single file. Select it in the workspace and use the **REPORT** action (the eye icon) or **View**. It contains:
+
+- the input structure and the models used, with the exact commands run
+- an interactive 3D viewer of the structure, colored by predicted probability
+- ranked tables of candidate positions
+- a per-residue stability track along the sequence
+- geometrically detected existing disulfide bonds
+- links to the sibling data files
+
+### Interpreting the scores
+
+The value in the B-factor column is a probability from 0 to 1. **Higher means a more favorable predicted site.** These are rankings, not free-energy predictions: the score orders candidates against each other, and the intended use is to select the top few positions for experimental testing.
+
+Two caveats when reading the outputs directly:
+
+- In the **proline** output, positions that are *already* proline typically score high — the model recognizes a proline-compatible environment. The TSV flags these with `already PRO` in its `note` column, since they are not actionable substitutions.
+- In the **disulfide** output, every residue carries a B-factor, but only cysteines are biologically meaningful for disulfide formation. The ranked TSV filters to CYS/CYX for this reason; the annotated PDB does not.
+
+### The ranked summaries
+
+Each TSV is ordered by probability, highest first:
+
+| Column | Description |
+|---|---|
+| `rank` | Position in the ranking, starting at 1 |
+| `chain` | Chain identifier (`-` if blank) |
+| `pos` | Residue number, with insertion code appended when present |
+| `residue` | Three-letter residue name |
+| `probability` | Predicted probability, 0–1, two decimal places |
+| `note` | Proline analysis only; `already PRO` where applicable |
+
+`<input>_summary.json` carries the same information for programmatic use, capped at the top 25 sites per analysis. The TSVs keep the full ranking.
+
+### Visualizing by score
+
+Because probabilities live in the B-factor column, any structure viewer can color by them. In the BV-BRC viewer, open an annotated PDB and color by B-factor: the highest-scoring positions stand out directly on the structure. The same file loads unmodified in PyMOL (`spectrum b`), ChimeraX, or Mol*.
+
+## Resource estimates
+
+These are ceilings the AppService uses for queue scheduling; actual compute is far below them.
+
+| Resource | Value | Notes |
+|---|---|---|
+| CPUs | 2 | Sufficient for GNN inference |
+| Memory | 1 GB | ~500 MB even for very large structures |
+| Time-out | 10 min | Dominated by container staging, not inference |
+
+Inference itself is sub-second for typical proteins; a complete `both` run on a small protein finishes in roughly 12–16 seconds end to end. Scaling is mild with size — disulfiNNate's edge computation grows with the square of residue count, so an 8,000-residue complex takes on the order of 20 seconds rather than 1.
+
+## References
+
+- stabiliNNator source: [github.com/schoederlab/stabiliNNator](https://github.com/schoederlab/stabiliNNator)
+- Veličković P et al. **Graph Attention Networks.** *ICLR* (2018). [arXiv:1710.10903](https://arxiv.org/abs/1710.10903)

--- a/docroot/quick_references/services_menu.rst
+++ b/docroot/quick_references/services_menu.rst
@@ -48,6 +48,8 @@ Protein Tools Services
    services/predict_structure_service.md
    services/predict_structure_cli.md
    services/predict_structure_api.md
+   services/stabilinnator_service.md
+   services/stabilinnator_api.md
 
 
 Metagenomics Services


### PR DESCRIPTION
Adds documentation for the Protein Stability Prediction (StabiliNNator) service, which currently has no pages in BV-BRC-Docs.

Two references, following the existing `predict_structure_*` layout, both registered in the **Protein Tools** section of `services_menu.rst`:

- **`services/stabilinnator_service.md`** — user-facing quick reference: the two analyses (proliNNator / disulfiNNate), every form field, the output file set, how to read the B-factor-encoded probabilities, and resource estimates.
- **`services/stabilinnator_api.md`** — AppService JSON-RPC reference: parameter table, validation rules, preflight values, result layout, the summary JSON schema, and worked submission examples.

## Accuracy

Content is derived from the app spec and service script rather than written from memory:

- parameters, defaults and enums match [`app_specs/StabiliNNator.json`](https://github.com/CEPI-dxkb/stabiliNNatorApp/blob/main/app_specs/StabiliNNator.json)
- the documented preflight block matches what the Perl preflight actually emits (`runtime 600`, `partition gpu2`, `gpu_count 0`)
- the summary-JSON example is real output from a crambin (1CRN) run, including the `top_sites` / `cys_sites` key names and the 25-site cap

## Build

Verified with Sphinx 5.3.0 and the package set from `singularity/build.def`. `build succeeded`; both pages render and appear in the nav.

The only warnings on the new pages are two `Could not lex literal_block as "json"` notices from the `{ ...values... }` placeholder blocks — `predict_structure_api.md` produces the same warning three times. An in-page anchor warning was found and fixed in the second commit (`myst_heading_anchors = 2` generates anchors for h1/h2 only; the link pointed at an h3).

## Deliberately not included

- **A CLI reference.** PredictStructure documents its native `predict-structure` CLI. StabiliNNator has no equivalent p3 wrapper, so the page would have to invent commands. The honest subject would be the CWL workflow plus direct invocation of the two Python tools — happy to add that if wanted.
- **A recipes / cookbook page.** PredictStructure needs one because its input space is combinatorial (6 engines x entity types x MSA options). This service takes one structure and a three-valued `analysis_type`, so a cookbook would amount to one genuine recipe plus padding.

## Update: tutorial added

A submission form now exists (BV-BRC/BV-BRC-Web#1407), so the tutorial could be written after all. `tutorial/stabilinnator/stabilinnator.md` is included here with four screenshots, registered in `tutorial/index.rst`.

It is written from a real run — job `StabiliNNator-260825-175439` on crambin (1CRN) — and every number in it comes from that job's report: 46 residues, 6 cysteines, top proline site THR 21 at 0.97, 40 scored proline sites, all 6 cysteines at 0.99–1.00, 3 disulfide bonds detected, 8.8 s service runtime.

The tutorial leads on **interpretation** rather than on driving the form, since that is where this service is easy to misread: the scores are rankings rather than free energies, high-scoring proline hits are frequently *already prolines* (five of crambin's top six), and every residue carries a disulfide B-factor although only cysteines are meaningful.

The quick reference was also restructured so the form's info-icons resolve. `AppBase` fetches the published quick-reference page and matches an infobox `name` against an element `id`; with `myst_heading_anchors = 2` only h1/h2 get anchors, so **Input Structure** and **Analysis** were promoted to h2 and **Report Theme** moved under **Output**, matching the form's three boxes. Verified in the built HTML that `#overview`, `#input-structure`, `#analysis` and `#output` all exist.

Two accuracy fixes came out of the real run: proliNNator scores all residues *except cysteines* (crambin's 46 residues yield 40 scored sites), and the old "Advanced options" section described `accelerator` / `hidden_dim` / `dry_run` as form fields — the form deliberately does not expose them, so that section now points at the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
